### PR TITLE
fix: save kernel stack position when exiting from trap handler on LoongArch64

### DIFF
--- a/src/loongarch64/trap.S
+++ b/src/loongarch64/trap.S
@@ -27,6 +27,8 @@
     csrwr   $r21, KSAVE_R21
     LDD     $tp,  $sp, 2
     LDD     $r21, $sp, 21
+    addi.d  $t1,  $sp, {trapframe_size}
+    csrwr   $t1,  KSAVE_KSP // save kernel sp
 .endif
 
     LDD     $t1,  $sp, 33       // era


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: [Fix kernel stack position on LoongArch64 #18](https://github.com/oscomp/arceos/pull/18)

## Description
This pull request includes a small change to the `src/loongarch64/trap.S` file. The change adds instructions to compute the kernel stack pointer (`$t1`) and save it in the `KSAVE_KSP` control status register.

## Additional Notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.
