### PR TITLE
feat: FP/SIMD support for LoongArch64 

### DIFF
--- a/src/loongarch64/context.rs
+++ b/src/loongarch64/context.rs
@@ -1,4 +1,5 @@
 use core::arch::naked_asm;
+use core::mem::offset_of;
 use memory_addr::VirtAddr;
 
 /// General registers of Loongarch64.
@@ -48,7 +49,7 @@ pub struct FpStatus {
     /// Floating-point registers (f0-f31)
     pub fp: [u64; 32],
     /// Floating-point Condition Code register
-    pub fcc: usize,
+    pub fcc: [u8; 8],
     /// Floating-point Control and Status register
     pub fcsr: usize,
 }
@@ -182,33 +183,37 @@ impl TaskContext {
 
 #[cfg(feature = "fp_simd")]
 #[unsafe(naked)]
-unsafe extern "C" fn save_fp_registers(_fp_status: &mut FpStatus) {
+unsafe extern "C" fn save_fp_registers(fp_status: &mut FpStatus) {
     naked_asm!(
         include_fp_asm_macros!(),
         "
         PUSH_FLOAT_REGS $a0
-        addi.d  $t8, $a0, 256
+        addi.d $t8, $a0, {fcc_offset}
         SAVE_FCC $t8
-        addi.d  $t8, $a0, 264
+        addi.d $t8, $a0, {fcsr_offset}
         SAVE_FCSR $t8
         ret
-        "
+        ",
+        fcc_offset = const offset_of!(FpStatus, fcc),
+        fcsr_offset = const offset_of!(FpStatus, fcsr),
     )
 }
 
 #[cfg(feature = "fp_simd")]
 #[unsafe(naked)]
-unsafe extern "C" fn restore_fp_registers(_fp_status: &FpStatus) {
+unsafe extern "C" fn restore_fp_registers(fp_status: &FpStatus) {
     naked_asm!(
         include_fp_asm_macros!(),
         "
         POP_FLOAT_REGS $a0
-        addi.d  $t8, $a0, 256
+        addi.d $t8, $a0, {fcc_offset}
         RESTORE_FCC $t8
-        addi.d  $t8, $a0, 264
+        addi.d $t8, $a0, {fcsr_offset}
         RESTORE_FCSR $t8
         ret
-        "
+        ",
+        fcc_offset = const offset_of!(FpStatus, fcc),
+        fcsr_offset = const offset_of!(FpStatus, fcsr),
     )
 }
 

--- a/src/loongarch64/context.rs
+++ b/src/loongarch64/context.rs
@@ -1,4 +1,5 @@
 use core::arch::naked_asm;
+#[cfg(feature = "fp_simd")]
 use core::mem::offset_of;
 use memory_addr::VirtAddr;
 
@@ -171,11 +172,9 @@ impl TaskContext {
             }
         }
         #[cfg(feature = "fp_simd")]
-        {
-            unsafe {
-                save_fp_registers(&mut self.fp_status);
-                restore_fp_registers(&next_ctx.fp_status);
-            }
+        unsafe {
+            save_fp_registers(&mut self.fp_status);
+            restore_fp_registers(&next_ctx.fp_status);
         }
         unsafe { context_switch(self, next_ctx) }
     }

--- a/src/loongarch64/context.rs
+++ b/src/loongarch64/context.rs
@@ -191,8 +191,7 @@ unsafe extern "C" fn save_fp_registers(fp_status: &mut FpStatus) {
         SAVE_FCC $t8
         addi.d $t8, $a0, {fcsr_offset}
         SAVE_FCSR $t8
-        ret
-        ",
+        ret",
         fcc_offset = const offset_of!(FpStatus, fcc),
         fcsr_offset = const offset_of!(FpStatus, fcsr),
     )
@@ -209,8 +208,7 @@ unsafe extern "C" fn restore_fp_registers(fp_status: &FpStatus) {
         RESTORE_FCC $t8
         addi.d $t8, $a0, {fcsr_offset}
         RESTORE_FCSR $t8
-        ret
-        ",
+        ret",
         fcc_offset = const offset_of!(FpStatus, fcc),
         fcsr_offset = const offset_of!(FpStatus, fcsr),
     )

--- a/src/loongarch64/context.rs
+++ b/src/loongarch64/context.rs
@@ -52,7 +52,7 @@ pub struct FpStatus {
     /// Floating-point Condition Code register
     pub fcc: [u8; 8],
     /// Floating-point Control and Status register
-    pub fcsr: usize,
+    pub fcsr: u32,
 }
 
 /// Saved registers when a trap (interrupt or exception) occurs.
@@ -186,7 +186,7 @@ unsafe extern "C" fn save_fp_registers(fp_status: &mut FpStatus) {
     naked_asm!(
         include_fp_asm_macros!(),
         "
-        PUSH_FLOAT_REGS $a0
+        SAVE_FP $a0
         addi.d $t8, $a0, {fcc_offset}
         SAVE_FCC $t8
         addi.d $t8, $a0, {fcsr_offset}
@@ -203,7 +203,7 @@ unsafe extern "C" fn restore_fp_registers(fp_status: &FpStatus) {
     naked_asm!(
         include_fp_asm_macros!(),
         "
-        POP_FLOAT_REGS $a0
+        RESTORE_FP $a0
         addi.d $t8, $a0, {fcc_offset}
         RESTORE_FCC $t8
         addi.d $t8, $a0, {fcsr_offset}

--- a/src/loongarch64/context.rs
+++ b/src/loongarch64/context.rs
@@ -187,6 +187,10 @@ unsafe extern "C" fn save_fp_registers(_fp_status: &mut FpStatus) {
         include_fp_asm_macros!(),
         "
         PUSH_FLOAT_REGS $a0
+        addi.d  $t8, $a0, 256
+        SAVE_FCC $t8
+        addi.d  $t8, $a0, 264
+        SAVE_FCSR $t8
         ret
         "
     )
@@ -199,6 +203,10 @@ unsafe extern "C" fn restore_fp_registers(_fp_status: &FpStatus) {
         include_fp_asm_macros!(),
         "
         POP_FLOAT_REGS $a0
+        addi.d  $t8, $a0, 256
+        RESTORE_FCC $t8
+        addi.d  $t8, $a0, 264
+        RESTORE_FCSR $t8
         ret
         "
     )

--- a/src/loongarch64/macros.rs
+++ b/src/loongarch64/macros.rs
@@ -81,17 +81,10 @@ macro_rules! include_asm_macros {
 macro_rules! include_fp_asm_macros {
     () => {
         concat!(
-            include_asm_macros!(), // Changed from __asm_macros!
+            include_asm_macros!(),
             r#"
             .ifndef FP_MACROS_FLAG
             .equ FP_MACROS_FLAG, 1
-
-            .macro FSTD fr, base_reg, off
-                fst.d   \fr, \base_reg, \off*8
-            .endm
-            .macro FLDD fr, base_reg, off
-                fld.d   \fr, \base_reg, \off*8
-            .endm
 
             .macro SAVE_FCSR, base
                 movfcsr2gr $t0, $fcsr0
@@ -178,10 +171,18 @@ macro_rules! include_fp_asm_macros {
 
             .macro PUSH_FLOAT_REGS, base_reg
                 PUSH_POP_FLOAT_REGS fst.d, \base_reg
+                addi.d  $t8, \base_reg, 256
+                SAVE_FCC $t8
+                addi.d  $t8, \base_reg, 264
+                SAVE_FCSR $t8
             .endm
 
             .macro POP_FLOAT_REGS, base_reg
                 PUSH_POP_FLOAT_REGS fld.d, \base_reg
+                addi.d  $t8, \base_reg, 256
+                RESTORE_FCC $t8
+                addi.d  $t8, \base_reg, 264
+                RESTORE_FCSR $t8
             .endm
 
             .endif"#

--- a/src/loongarch64/macros.rs
+++ b/src/loongarch64/macros.rs
@@ -105,33 +105,33 @@ macro_rules! include_fp_asm_macros {
         .endm
 
         .macro RESTORE_FCC, base
-            ld.d	    $t0, \base, 0
-            bstrpick.d	$t1, $t0, 7, 0
-            movgr2cf	$fcc0, $t1
-            bstrpick.d	$t1, $t0, 15, 8
-            movgr2cf	$fcc1, $t1
-            bstrpick.d	$t1, $t0, 23, 16
-            movgr2cf	$fcc2, $t1
-            bstrpick.d	$t1, $t0, 31, 24
-            movgr2cf	$fcc3, $t1
-            bstrpick.d	$t1, $t0, 39, 32
-            movgr2cf	$fcc4, $t1
-            bstrpick.d	$t1, $t0, 47, 40
-            movgr2cf	$fcc5, $t1
-            bstrpick.d	$t1, $t0, 55, 48
-            movgr2cf	$fcc6, $t1
-            bstrpick.d	$t1, $t0, 63, 56
-            movgr2cf	$fcc7, $t1
+            ld.d        $t0, \base, 0
+            bstrpick.d  $t1, $t0, 7, 0
+            movgr2cf    $fcc0, $t1
+            bstrpick.d  $t1, $t0, 15, 8
+            movgr2cf    $fcc1, $t1
+            bstrpick.d  $t1, $t0, 23, 16
+            movgr2cf    $fcc2, $t1
+            bstrpick.d  $t1, $t0, 31, 24
+            movgr2cf    $fcc3, $t1
+            bstrpick.d  $t1, $t0, 39, 32
+            movgr2cf    $fcc4, $t1
+            bstrpick.d  $t1, $t0, 47, 40
+            movgr2cf    $fcc5, $t1
+            bstrpick.d  $t1, $t0, 55, 48
+            movgr2cf    $fcc6, $t1
+            bstrpick.d  $t1, $t0, 63, 56
+            movgr2cf    $fcc7, $t1
         .endm
 
         .macro SAVE_FCSR, base
-            movfcsr2gr	$t0, $fcsr0
+            movfcsr2gr  $t0, $fcsr0
             st.w        $t0, \base, 0
         .endm
 
         .macro RESTORE_FCSR, base
             ld.w        $t0, \base, 0
-            movgr2fcsr	$fcsr0, $t0
+            movgr2fcsr  $fcsr0, $t0
         .endm
 
         // LoongArch64 specific floating point macros

--- a/src/loongarch64/macros.rs
+++ b/src/loongarch64/macros.rs
@@ -76,3 +76,115 @@ macro_rules! include_asm_macros {
         .endif"
     };
 }
+
+#[cfg(feature = "fp_simd")]
+macro_rules! include_fp_asm_macros {
+    () => {
+        concat!(
+            include_asm_macros!(), // Changed from __asm_macros!
+            r#"
+            .ifndef FP_MACROS_FLAG
+            .equ FP_MACROS_FLAG, 1
+
+            .macro FSTD fr, base_reg, off
+                fst.d   \fr, \base_reg, \off*8
+            .endm
+            .macro FLDD fr, base_reg, off
+                fld.d   \fr, \base_reg, \off*8
+            .endm
+
+            .macro SAVE_FCSR, base
+                movfcsr2gr $t0, $fcsr0
+                st.d $t0, \base, 0*8
+            .endm
+            .macro SAVE_FCC, base
+                movcf2gr $t0, $fcc0
+                movcf2gr $t1, $fcc1
+                movcf2gr $t2, $fcc2
+                movcf2gr $t3, $fcc3
+                movcf2gr $t4, $fcc4
+                movcf2gr $t5, $fcc5
+                movcf2gr $t6, $fcc6
+                movcf2gr $t7, $fcc7
+                st.d $t0, \base, 0
+                st.d $t1, \base, 1
+                st.d $t2, \base, 2
+                st.d $t3, \base, 3
+                st.d $t4, \base, 4
+                st.d $t5, \base, 5
+                st.d $t6, \base, 6
+                st.d $t7, \base, 7
+            .endm
+
+            .macro RESTORE_FCSR, base
+                movgr2fcsr $fcsr0, $t0
+                ld.d $t0, \base, 0*8
+            .endm
+            .macro RESTORE_FCC, base
+                ld.d $t0, \base, 0
+                ld.d $t1, \base, 1
+                ld.d $t2, \base, 2
+                ld.d $t3, \base, 3
+                ld.d $t4, \base, 4
+                ld.d $t5, \base, 5
+                ld.d $t6, \base, 6
+                ld.d $t7, \base, 7
+                movgr2cf $fcc0, $t0
+                movgr2cf $fcc1, $t1
+                movgr2cf $fcc2, $t2
+                movgr2cf $fcc3, $t3
+                movgr2cf $fcc4, $t4
+                movgr2cf $fcc5, $t5
+                movgr2cf $fcc6, $t6
+                movgr2cf $fcc7, $t7
+            .endm
+
+
+            // LoongArch64 specific floating point macros
+            .macro PUSH_POP_FLOAT_REGS, op, base_reg
+                \op $f0,  \base_reg, 0*8
+                \op $f1,  \base_reg, 1*8
+                \op $f2,  \base_reg, 2*8
+                \op $f3,  \base_reg, 3*8
+                \op $f4,  \base_reg, 4*8
+                \op $f5,  \base_reg, 5*8
+                \op $f6,  \base_reg, 6*8
+                \op $f7,  \base_reg, 7*8
+                \op $f8,  \base_reg, 8*8
+                \op $f9,  \base_reg, 9*8
+                \op $f10, \base_reg, 10*8
+                \op $f11, \base_reg, 11*8
+                \op $f12, \base_reg, 12*8
+                \op $f13, \base_reg, 13*8
+                \op $f14, \base_reg, 14*8
+                \op $f15, \base_reg, 15*8
+                \op $f16, \base_reg, 16*8
+                \op $f17, \base_reg, 17*8
+                \op $f18, \base_reg, 18*8
+                \op $f19, \base_reg, 19*8
+                \op $f20, \base_reg, 20*8
+                \op $f21, \base_reg, 21*8
+                \op $f22, \base_reg, 22*8
+                \op $f23, \base_reg, 23*8
+                \op $f24, \base_reg, 24*8
+                \op $f25, \base_reg, 25*8
+                \op $f26, \base_reg, 26*8
+                \op $f27, \base_reg, 27*8
+                \op $f28, \base_reg, 28*8
+                \op $f29, \base_reg, 29*8
+                \op $f30, \base_reg, 30*8
+                \op $f31, \base_reg, 31*8
+            .endm
+
+            .macro PUSH_FLOAT_REGS, base_reg
+                PUSH_POP_FLOAT_REGS fst.d, \base_reg
+            .endm
+
+            .macro POP_FLOAT_REGS, base_reg
+                PUSH_POP_FLOAT_REGS fld.d, \base_reg
+            .endm
+
+            .endif"#
+        )
+    };
+}

--- a/src/loongarch64/macros.rs
+++ b/src/loongarch64/macros.rs
@@ -84,52 +84,55 @@ macro_rules! include_fp_asm_macros {
         .ifndef FP_MACROS_FLAG
         .equ FP_MACROS_FLAG, 1
 
-        .macro SAVE_FCSR, base
-            movfcsr2gr $t0, $fcsr0
-            st.d $t0, \base, 0*8
-        .endm
         .macro SAVE_FCC, base
-            movcf2gr $t0, $fcc0
-            movcf2gr $t1, $fcc1
-            movcf2gr $t2, $fcc2
-            movcf2gr $t3, $fcc3
-            movcf2gr $t4, $fcc4
-            movcf2gr $t5, $fcc5
-            movcf2gr $t6, $fcc6
-            movcf2gr $t7, $fcc7
-            st.d $t0, \base, 0
-            st.d $t1, \base, 1
-            st.d $t2, \base, 2
-            st.d $t3, \base, 3
-            st.d $t4, \base, 4
-            st.d $t5, \base, 5
-            st.d $t6, \base, 6
-            st.d $t7, \base, 7
+            movcf2gr    $t0, $fcc0
+            move        $t1, $t0
+            movcf2gr    $t0, $fcc1
+            bstrins.d   $t1, $t0, 15, 8
+            movcf2gr    $t0, $fcc2
+            bstrins.d   $t1, $t0, 23, 16
+            movcf2gr    $t0, $fcc3
+            bstrins.d   $t1, $t0, 31, 24
+            movcf2gr    $t0, $fcc4
+            bstrins.d   $t1, $t0, 39, 32
+            movcf2gr    $t0, $fcc5
+            bstrins.d   $t1, $t0, 47, 40
+            movcf2gr    $t0, $fcc6
+            bstrins.d   $t1, $t0, 55, 48
+            movcf2gr    $t0, $fcc7
+            bstrins.d   $t1, $t0, 63, 56
+            st.d        $t1, \base, 0
+        .endm
+
+        .macro RESTORE_FCC, base
+            ld.d	    $t0, \base, 0
+            bstrpick.d	$t1, $t0, 7, 0
+            movgr2cf	$fcc0, $t1
+            bstrpick.d	$t1, $t0, 15, 8
+            movgr2cf	$fcc1, $t1
+            bstrpick.d	$t1, $t0, 23, 16
+            movgr2cf	$fcc2, $t1
+            bstrpick.d	$t1, $t0, 31, 24
+            movgr2cf	$fcc3, $t1
+            bstrpick.d	$t1, $t0, 39, 32
+            movgr2cf	$fcc4, $t1
+            bstrpick.d	$t1, $t0, 47, 40
+            movgr2cf	$fcc5, $t1
+            bstrpick.d	$t1, $t0, 55, 48
+            movgr2cf	$fcc6, $t1
+            bstrpick.d	$t1, $t0, 63, 56
+            movgr2cf	$fcc7, $t1
+        .endm
+
+        .macro SAVE_FCSR, base
+            movfcsr2gr	$t0, $fcsr0
+            st.w        $t0, \base, 0
         .endm
 
         .macro RESTORE_FCSR, base
-            movgr2fcsr $fcsr0, $t0
-            ld.d $t0, \base, 0*8
+            ld.w        $t0, \base, 0
+            movgr2fcsr	$fcsr0, $t0
         .endm
-        .macro RESTORE_FCC, base
-            ld.d $t0, \base, 0
-            ld.d $t1, \base, 1
-            ld.d $t2, \base, 2
-            ld.d $t3, \base, 3
-            ld.d $t4, \base, 4
-            ld.d $t5, \base, 5
-            ld.d $t6, \base, 6
-            ld.d $t7, \base, 7
-            movgr2cf $fcc0, $t0
-            movgr2cf $fcc1, $t1
-            movgr2cf $fcc2, $t2
-            movgr2cf $fcc3, $t3
-            movgr2cf $fcc4, $t4
-            movgr2cf $fcc5, $t5
-            movgr2cf $fcc6, $t6
-            movgr2cf $fcc7, $t7
-        .endm
-
 
         // LoongArch64 specific floating point macros
         .macro PUSH_POP_FLOAT_REGS, op, base_reg

--- a/src/loongarch64/macros.rs
+++ b/src/loongarch64/macros.rs
@@ -80,112 +80,101 @@ macro_rules! include_asm_macros {
 #[cfg(feature = "fp_simd")]
 macro_rules! include_fp_asm_macros {
     () => {
-        concat!(
-            include_asm_macros!(),
-            r#"
-            .ifndef FP_MACROS_FLAG
-            .equ FP_MACROS_FLAG, 1
+        r#"
+        .ifndef FP_MACROS_FLAG
+        .equ FP_MACROS_FLAG, 1
 
-            .macro SAVE_FCSR, base
-                movfcsr2gr $t0, $fcsr0
-                st.d $t0, \base, 0*8
-            .endm
-            .macro SAVE_FCC, base
-                movcf2gr $t0, $fcc0
-                movcf2gr $t1, $fcc1
-                movcf2gr $t2, $fcc2
-                movcf2gr $t3, $fcc3
-                movcf2gr $t4, $fcc4
-                movcf2gr $t5, $fcc5
-                movcf2gr $t6, $fcc6
-                movcf2gr $t7, $fcc7
-                st.d $t0, \base, 0
-                st.d $t1, \base, 1
-                st.d $t2, \base, 2
-                st.d $t3, \base, 3
-                st.d $t4, \base, 4
-                st.d $t5, \base, 5
-                st.d $t6, \base, 6
-                st.d $t7, \base, 7
-            .endm
+        .macro SAVE_FCSR, base
+            movfcsr2gr $t0, $fcsr0
+            st.d $t0, \base, 0*8
+        .endm
+        .macro SAVE_FCC, base
+            movcf2gr $t0, $fcc0
+            movcf2gr $t1, $fcc1
+            movcf2gr $t2, $fcc2
+            movcf2gr $t3, $fcc3
+            movcf2gr $t4, $fcc4
+            movcf2gr $t5, $fcc5
+            movcf2gr $t6, $fcc6
+            movcf2gr $t7, $fcc7
+            st.d $t0, \base, 0
+            st.d $t1, \base, 1
+            st.d $t2, \base, 2
+            st.d $t3, \base, 3
+            st.d $t4, \base, 4
+            st.d $t5, \base, 5
+            st.d $t6, \base, 6
+            st.d $t7, \base, 7
+        .endm
 
-            .macro RESTORE_FCSR, base
-                movgr2fcsr $fcsr0, $t0
-                ld.d $t0, \base, 0*8
-            .endm
-            .macro RESTORE_FCC, base
-                ld.d $t0, \base, 0
-                ld.d $t1, \base, 1
-                ld.d $t2, \base, 2
-                ld.d $t3, \base, 3
-                ld.d $t4, \base, 4
-                ld.d $t5, \base, 5
-                ld.d $t6, \base, 6
-                ld.d $t7, \base, 7
-                movgr2cf $fcc0, $t0
-                movgr2cf $fcc1, $t1
-                movgr2cf $fcc2, $t2
-                movgr2cf $fcc3, $t3
-                movgr2cf $fcc4, $t4
-                movgr2cf $fcc5, $t5
-                movgr2cf $fcc6, $t6
-                movgr2cf $fcc7, $t7
-            .endm
+        .macro RESTORE_FCSR, base
+            movgr2fcsr $fcsr0, $t0
+            ld.d $t0, \base, 0*8
+        .endm
+        .macro RESTORE_FCC, base
+            ld.d $t0, \base, 0
+            ld.d $t1, \base, 1
+            ld.d $t2, \base, 2
+            ld.d $t3, \base, 3
+            ld.d $t4, \base, 4
+            ld.d $t5, \base, 5
+            ld.d $t6, \base, 6
+            ld.d $t7, \base, 7
+            movgr2cf $fcc0, $t0
+            movgr2cf $fcc1, $t1
+            movgr2cf $fcc2, $t2
+            movgr2cf $fcc3, $t3
+            movgr2cf $fcc4, $t4
+            movgr2cf $fcc5, $t5
+            movgr2cf $fcc6, $t6
+            movgr2cf $fcc7, $t7
+        .endm
 
 
-            // LoongArch64 specific floating point macros
-            .macro PUSH_POP_FLOAT_REGS, op, base_reg
-                \op $f0,  \base_reg, 0*8
-                \op $f1,  \base_reg, 1*8
-                \op $f2,  \base_reg, 2*8
-                \op $f3,  \base_reg, 3*8
-                \op $f4,  \base_reg, 4*8
-                \op $f5,  \base_reg, 5*8
-                \op $f6,  \base_reg, 6*8
-                \op $f7,  \base_reg, 7*8
-                \op $f8,  \base_reg, 8*8
-                \op $f9,  \base_reg, 9*8
-                \op $f10, \base_reg, 10*8
-                \op $f11, \base_reg, 11*8
-                \op $f12, \base_reg, 12*8
-                \op $f13, \base_reg, 13*8
-                \op $f14, \base_reg, 14*8
-                \op $f15, \base_reg, 15*8
-                \op $f16, \base_reg, 16*8
-                \op $f17, \base_reg, 17*8
-                \op $f18, \base_reg, 18*8
-                \op $f19, \base_reg, 19*8
-                \op $f20, \base_reg, 20*8
-                \op $f21, \base_reg, 21*8
-                \op $f22, \base_reg, 22*8
-                \op $f23, \base_reg, 23*8
-                \op $f24, \base_reg, 24*8
-                \op $f25, \base_reg, 25*8
-                \op $f26, \base_reg, 26*8
-                \op $f27, \base_reg, 27*8
-                \op $f28, \base_reg, 28*8
-                \op $f29, \base_reg, 29*8
-                \op $f30, \base_reg, 30*8
-                \op $f31, \base_reg, 31*8
-            .endm
+        // LoongArch64 specific floating point macros
+        .macro PUSH_POP_FLOAT_REGS, op, base_reg
+            \op $f0,  \base_reg, 0*8
+            \op $f1,  \base_reg, 1*8
+            \op $f2,  \base_reg, 2*8
+            \op $f3,  \base_reg, 3*8
+            \op $f4,  \base_reg, 4*8
+            \op $f5,  \base_reg, 5*8
+            \op $f6,  \base_reg, 6*8
+            \op $f7,  \base_reg, 7*8
+            \op $f8,  \base_reg, 8*8
+            \op $f9,  \base_reg, 9*8
+            \op $f10, \base_reg, 10*8
+            \op $f11, \base_reg, 11*8
+            \op $f12, \base_reg, 12*8
+            \op $f13, \base_reg, 13*8
+            \op $f14, \base_reg, 14*8
+            \op $f15, \base_reg, 15*8
+            \op $f16, \base_reg, 16*8
+            \op $f17, \base_reg, 17*8
+            \op $f18, \base_reg, 18*8
+            \op $f19, \base_reg, 19*8
+            \op $f20, \base_reg, 20*8
+            \op $f21, \base_reg, 21*8
+            \op $f22, \base_reg, 22*8
+            \op $f23, \base_reg, 23*8
+            \op $f24, \base_reg, 24*8
+            \op $f25, \base_reg, 25*8
+            \op $f26, \base_reg, 26*8
+            \op $f27, \base_reg, 27*8
+            \op $f28, \base_reg, 28*8
+            \op $f29, \base_reg, 29*8
+            \op $f30, \base_reg, 30*8
+            \op $f31, \base_reg, 31*8
+        .endm
 
-            .macro PUSH_FLOAT_REGS, base_reg
-                PUSH_POP_FLOAT_REGS fst.d, \base_reg
-                addi.d  $t8, \base_reg, 256
-                SAVE_FCC $t8
-                addi.d  $t8, \base_reg, 264
-                SAVE_FCSR $t8
-            .endm
+        .macro PUSH_FLOAT_REGS, base_reg
+            PUSH_POP_FLOAT_REGS fst.d, \base_reg
+        .endm
 
-            .macro POP_FLOAT_REGS, base_reg
-                PUSH_POP_FLOAT_REGS fld.d, \base_reg
-                addi.d  $t8, \base_reg, 256
-                RESTORE_FCC $t8
-                addi.d  $t8, \base_reg, 264
-                RESTORE_FCSR $t8
-            .endm
+        .macro POP_FLOAT_REGS, base_reg
+            PUSH_POP_FLOAT_REGS fld.d, \base_reg
+        .endm
 
-            .endif"#
-        )
+        .endif"#
     };
 }

--- a/src/loongarch64/macros.rs
+++ b/src/loongarch64/macros.rs
@@ -170,11 +170,11 @@ macro_rules! include_fp_asm_macros {
             \op $f31, \base_reg, 31*8
         .endm
 
-        .macro PUSH_FLOAT_REGS, base_reg
+        .macro SAVE_FP, base_reg
             PUSH_POP_FLOAT_REGS fst.d, \base_reg
         .endm
 
-        .macro POP_FLOAT_REGS, base_reg
+        .macro RESTORE_FP, base_reg
             PUSH_POP_FLOAT_REGS fld.d, \base_reg
         .endm
 


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: [Support fp_simd for for LA #41](https://github.com/oscomp/arceos/pull/41)

## Background
https://github.com/oscomp/arceos/issues/26:  fp_state scheduling context preservation is NOT available on and loongarch64.

## Description
It introduces significant updates to support floating-point SIMD operations for LoongArch64.
Including changes to context management, assembly macros, and task switching logic, ensuring proper handling of floating-point registers and states during task execution and context switching.

- added a new FpStatus struct.
- extended TaskContext to handle floating-point states.
- add `include_fp_asm_macros`.

## Additional Notes
Compared to the original commits, `#[naked]` has been updated into `#[unsafe(naked)]` to adapt to the latest toolchain
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.

## Known issues
Originally posted by @Azure-stars in https://github.com/arceos-org/axcpu/issues/2#issuecomment-2967429566_
Logging output in kernel mode can cause changes in floating-point registers, resulting in inconsistent states before and after program switching.
The current solution is to enable `soft-float` when compiling the OS.

After a whole afternoon of debugging, the confirmed situation is as follows:
1. No floating-point instructions other than save/restore FP were found in asm file of Starry next.
2. Log output before saving and after restoring FP will result in FP inconsistency.
3. If FPE is manually turned off before log output and turned on again after output, there's NO Unhandled trap Exception(FloatingPointUnavailable), but still have FP inconsistency, like:
```rust
#[cfg(feature = "fp_simd")]
unsafe {
    loongArch64::register::euen::set_fpe(false);
    error!("say sth");
    loongArch64::register::euen::set_fpe(true);
    save_fp_registers(&mut self.fp_status);
    restore_fp_registers(&next_ctx.fp_status);
}
// have FP inconsistency
```
4. If `soft-float` is enabled for the kernel, there will be no issues.
5. Logging output under the RISCV architecture, there will be no issues.


I think points 1 and 3 can confirm that there are no floating-point instructions in the log output itself, but why this bug is caused still needs to be explored.

Attached in Chinese to prevent misunderstandings: 经过一下午的调试，目前可以确认的情况如下：
1. 对Starry-next反编译没有发现除保存/恢复FP之外的浮点指令。
2. 在保存FP前和恢复FP后进行日志输出均会出现FP不一致。
3. 若在日志输出前手动关闭FPE，输出后再次开启，不会出现Unhandled trap Exception(FloatingPointUnavailable)，且仍会有FP不一致现象。
4. 若对内核启用软浮点，则不会出现任何问题。
5. 在RISCV架构下进行日志输出不会出现FP不一致问题。
﻿
我认为1,3两点可以确认日志输出本身不存在浮点指令，但为什么导致这个bug，还搞不明白，仍然亟待探寻。