### PR TITLE
[build] rename fp_simd feature as fp-simd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         rust-toolchain: [nightly]
-        targets: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, loongarch64-unknown-none-softfloat]
+        targets: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.89.0"
 
 [features]
 default = []
-fp_simd = []
+fp-simd = []
 tls = []
 uspace = []
 
@@ -55,4 +55,4 @@ page_table_multiarch = "0.5"
 new_without_default = "allow"
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-none", "aarch64-unknown-none", "riscv64gc-unknown-none-elf", "loongarch64-unknown-none"]
+targets = ["x86_64-unknown-none", "aarch64-unknown-none-softfloat", "riscv64gc-unknown-none-elf", "loongarch64-unknown-none-softfloat"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,6 +5,6 @@ components = ["rustfmt", "clippy"]
 targets = [
     "x86_64-unknown-none",
     "riscv64gc-unknown-none-elf",
-    "aarch64-unknown-none",
+    "aarch64-unknown-none-softfloat",
     "loongarch64-unknown-none-softfloat",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2025-05-12"
+channel = "nightly"
 components = ["rustfmt", "clippy"]
 targets = [
     "x86_64-unknown-none",

--- a/src/aarch64/init.rs
+++ b/src/aarch64/init.rs
@@ -96,11 +96,9 @@ pub unsafe fn init_mmu(root_paddr: PhysAddr) {
 
 /// Initializes trap handling on the current CPU.
 ///
-/// `cpu_id` indicates the CPU ID of the current CPU.
-///
 /// In detail, it initializes the exception vector, and sets `TTBR0_EL1` to 0 to
 /// block low address access.
-pub fn init_trap(_cpu_id: usize) {
+pub fn init_trap() {
     unsafe extern "C" {
         fn exception_vector_base();
     }

--- a/src/aarch64/init.rs
+++ b/src/aarch64/init.rs
@@ -94,13 +94,13 @@ pub unsafe fn init_mmu(root_paddr: PhysAddr) {
     barrier::isb(barrier::SY);
 }
 
-/// Initializes CPU states on the current CPU.
+/// Initializes trap handling on the current CPU.
 ///
 /// `cpu_id` indicates the CPU ID of the current CPU.
 ///
 /// In detail, it initializes the exception vector, and sets `TTBR0_EL1` to 0 to
 /// block low address access.
-pub fn init_cpu(_cpu_id: usize) {
+pub fn init_trap(_cpu_id: usize) {
     unsafe extern "C" {
         fn exception_vector_base();
     }

--- a/src/loongarch64/context.rs
+++ b/src/loongarch64/context.rs
@@ -1,5 +1,5 @@
 use core::arch::naked_asm;
-#[cfg(feature = "fp_simd")]
+#[cfg(feature = "fp-simd")]
 use core::mem::offset_of;
 use memory_addr::VirtAddr;
 
@@ -43,7 +43,7 @@ pub struct GeneralRegisters {
 }
 
 /// Floating-point registers of LoongArch64
-#[cfg(feature = "fp_simd")]
+#[cfg(feature = "fp-simd")]
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FpStatus {
@@ -55,7 +55,7 @@ pub struct FpStatus {
     pub fcsr: u32,
 }
 
-#[cfg(feature = "fp_simd")]
+#[cfg(feature = "fp-simd")]
 impl FpStatus {
     #[inline]
     pub unsafe fn save(&mut self) {
@@ -137,7 +137,7 @@ pub struct TaskContext {
     #[cfg(feature = "uspace")]
     /// user page table root
     pub pgdl: usize,
-    #[cfg(feature = "fp_simd")]
+    #[cfg(feature = "fp-simd")]
     /// Floating Point Status
     pub fp_status: FpStatus,
 }
@@ -183,7 +183,7 @@ impl TaskContext {
                 crate::asm::flush_tlb(None); // currently flush the entire TLB
             }
         }
-        #[cfg(feature = "fp_simd")]
+        #[cfg(feature = "fp-simd")]
         unsafe {
             self.fp_status.save();
             next_ctx.fp_status.restore();
@@ -192,7 +192,7 @@ impl TaskContext {
     }
 }
 
-#[cfg(feature = "fp_simd")]
+#[cfg(feature = "fp-simd")]
 #[unsafe(naked)]
 unsafe extern "C" fn save_fp_registers(fp_status: &mut FpStatus) {
     naked_asm!(
@@ -209,7 +209,7 @@ unsafe extern "C" fn save_fp_registers(fp_status: &mut FpStatus) {
     )
 }
 
-#[cfg(feature = "fp_simd")]
+#[cfg(feature = "fp-simd")]
 #[unsafe(naked)]
 unsafe extern "C" fn restore_fp_registers(fp_status: &FpStatus) {
     naked_asm!(

--- a/src/loongarch64/init.rs
+++ b/src/loongarch64/init.rs
@@ -38,10 +38,8 @@ pub fn init_mmu(root_paddr: PhysAddr, phys_virt_offset: usize) {
 
 /// Initializes trap handling on the current CPU.
 ///
-/// `cpu_id` indicates the CPU ID of the current CPU.
-///
 /// In detail, it initializes the exception vector on LoongArch64 platforms.
-pub fn init_trap(_cpu_id: usize) {
+pub fn init_trap() {
     unsafe extern "C" {
         fn exception_entry_base();
     }

--- a/src/loongarch64/init.rs
+++ b/src/loongarch64/init.rs
@@ -36,12 +36,12 @@ pub fn init_mmu(root_paddr: PhysAddr, phys_virt_offset: usize) {
     crmd::set_pg(true);
 }
 
-/// Initializes CPU states on the current CPU.
+/// Initializes trap handling on the current CPU.
 ///
 /// `cpu_id` indicates the CPU ID of the current CPU.
 ///
 /// In detail, it initializes the exception vector on LoongArch64 platforms.
-pub fn init_cpu(_cpu_id: usize) {
+pub fn init_trap(_cpu_id: usize) {
     unsafe extern "C" {
         fn exception_entry_base();
     }

--- a/src/loongarch64/macros.rs
+++ b/src/loongarch64/macros.rs
@@ -77,7 +77,7 @@ macro_rules! include_asm_macros {
     };
 }
 
-#[cfg(feature = "fp_simd")]
+#[cfg(feature = "fp-simd")]
 macro_rules! include_fp_asm_macros {
     () => {
         r#"

--- a/src/riscv/init.rs
+++ b/src/riscv/init.rs
@@ -2,10 +2,8 @@
 
 /// Initializes trap handling on the current CPU.
 ///
-/// `cpu_id` indicates the CPU ID of the current CPU.
-///
 /// In detail, it initializes the trap vector on RISC-V platforms.
-pub fn init_trap(_cpu_id: usize) {
+pub fn init_trap() {
     unsafe extern "C" {
         fn trap_vector_base();
     }

--- a/src/riscv/init.rs
+++ b/src/riscv/init.rs
@@ -1,11 +1,11 @@
 //! Helper functions to initialize the CPU states on systems bootstrapping.
 
-/// Initializes CPU states on the current CPU.
+/// Initializes trap handling on the current CPU.
 ///
 /// `cpu_id` indicates the CPU ID of the current CPU.
 ///
 /// In detail, it initializes the trap vector on RISC-V platforms.
-pub fn init_cpu(_cpu_id: usize) {
+pub fn init_trap(_cpu_id: usize) {
     unsafe extern "C" {
         fn trap_vector_base();
     }

--- a/src/x86_64/context.rs
+++ b/src/x86_64/context.rs
@@ -112,7 +112,7 @@ pub struct ExtendedState {
     pub fxsave_area: FxsaveArea,
 }
 
-#[cfg(feature = "fp_simd")]
+#[cfg(feature = "fp-simd")]
 impl ExtendedState {
     #[inline]
     fn save(&mut self) {
@@ -172,7 +172,7 @@ pub struct TaskContext {
     #[cfg(feature = "uspace")]
     pub gs_base: usize,
     /// Extended states, i.e., FP/SIMD states.
-    #[cfg(feature = "fp_simd")]
+    #[cfg(feature = "fp-simd")]
     pub ext_state: ExtendedState,
     /// The `CR3` register value, i.e., the page table root.
     #[cfg(feature = "uspace")]
@@ -194,7 +194,7 @@ impl TaskContext {
             fs_base: 0,
             #[cfg(feature = "uspace")]
             cr3: crate::asm::read_kernel_page_table(),
-            #[cfg(feature = "fp_simd")]
+            #[cfg(feature = "fp-simd")]
             ext_state: ExtendedState::default(),
             #[cfg(feature = "uspace")]
             gs_base: 0,
@@ -237,7 +237,7 @@ impl TaskContext {
     /// It first saves the current task's context from CPU to this place, and then
     /// restores the next task's context from `next_ctx` to CPU.
     pub fn switch_to(&mut self, next_ctx: &Self) {
-        #[cfg(feature = "fp_simd")]
+        #[cfg(feature = "fp-simd")]
         {
             self.ext_state.save();
             next_ctx.ext_state.restore();

--- a/src/x86_64/init.rs
+++ b/src/x86_64/init.rs
@@ -6,7 +6,7 @@ pub use super::idt::init_idt;
 #[cfg(feature = "uspace")]
 pub use super::syscall::init_syscall;
 
-/// Initializes CPU states on the current CPU.
+/// Initializes trap handling on the current CPU.
 ///
 /// `cpu_id` indicates the CPU ID of the current CPU.
 ///
@@ -17,7 +17,7 @@ pub use super::syscall::init_syscall;
 ///
 /// It also calls the initialization function of the [`percpu`] crate to use the
 /// per-CPU data.
-pub fn init_cpu(cpu_id: usize) {
+pub fn init_trap(cpu_id: usize) {
     // it's safe to call this function multiple times, the `percpu` crate
     // guarantees the actual initialization is only done once.
     percpu::init();

--- a/src/x86_64/init.rs
+++ b/src/x86_64/init.rs
@@ -8,20 +8,16 @@ pub use super::syscall::init_syscall;
 
 /// Initializes trap handling on the current CPU.
 ///
-/// `cpu_id` indicates the CPU ID of the current CPU.
-///
 /// In detail, it initializes the GDT, IDT on x86_64 platforms ([`init_gdt`] and
 /// [`init_idt`]). If the `uspace` feature is enabled, it also initializes
 /// relevant model-specific registers to configure the handler for `syscall`
 /// instruction ([`init_syscall`]).
 ///
-/// It also calls the initialization function of the [`percpu`] crate to use the
-/// per-CPU data.
-pub fn init_trap(cpu_id: usize) {
-    // it's safe to call this function multiple times, the `percpu` crate
-    // guarantees the actual initialization is only done once.
-    percpu::init();
-    percpu::init_percpu_reg(cpu_id);
+/// # Notes
+/// Before calling this function, the initialization function of the [`percpu`] crate
+/// should have been invoked to ensure that the per-CPU data structures are set up
+/// correctly.
+pub fn init_trap() {
     init_gdt();
     init_idt();
     #[cfg(feature = "uspace")]


### PR DESCRIPTION
This PR finish two task:
1. Rename `fp_simd` feature as `fp-simd` to maintain consistency with other features.
2. Always use `-softfloat` target for `aarch64` and `loongarch64`(See https://github.com/arceos-org/arceos/pull/255).
