### PR TITLE
update aarch64 hv part in arceos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ default = []
 fp-simd = []
 tls = []
 uspace = []
+arm-el2 = []
 
 [dependencies]
 linkme = "0.3"

--- a/src/aarch64/asm.rs
+++ b/src/aarch64/asm.rs
@@ -49,7 +49,12 @@ pub fn halt() {
 /// Returns the physical address of the page table root.
 #[inline]
 pub fn read_kernel_page_table() -> PhysAddr {
+    #[cfg(not(feature = "hv"))]
     let root = TTBR1_EL1.get();
+
+    #[cfg(feature = "hv")]
+    let root = TTBR0_EL2.get();
+
     pa!(root as usize)
 }
 
@@ -72,8 +77,17 @@ pub fn read_user_page_table() -> PhysAddr {
 /// This function is unsafe as it changes the virtual memory address space.
 #[inline]
 pub unsafe fn write_kernel_page_table(root_paddr: PhysAddr) {
-    // kernel space page table use TTBR1 (0xffff_0000_0000_0000..0xffff_ffff_ffff_ffff)
-    TTBR1_EL1.set(root_paddr.as_usize() as _);
+    #[cfg(not(feature = "hv"))]
+    {
+        // kernel space page table use TTBR1 (0xffff_0000_0000_0000..0xffff_ffff_ffff_ffff)
+        TTBR1_EL1.set(root_paddr.as_usize() as _);
+    }
+
+    #[cfg(feature = "hv")]
+    {
+        // kernel space page table at EL2 use TTBR0_EL2 (0x0000_0000_0000_0000..0x0000_ffff_ffff_ffff)
+        TTBR0_EL2.set(root_paddr.as_usize() as _);
+    }
 }
 
 /// Writes the register to update the current page table root for user space
@@ -97,10 +111,24 @@ pub unsafe fn write_user_page_table(root_paddr: PhysAddr) {
 pub fn flush_tlb(vaddr: Option<VirtAddr>) {
     unsafe {
         if let Some(vaddr) = vaddr {
-            asm!("tlbi vaae1is, {}; dsb sy; isb", in(reg) vaddr.as_usize())
+            #[cfg(not(feature = "hv"))]
+            {
+                asm!("tlbi vaae1is, {}; dsb sy; isb", in(reg) vaddr.as_usize())
+            }
+            #[cfg(feature = "hv")]
+            {
+                asm!("tlbi vae2is, {}; dsb sy; isb", in(reg) vaddr.as_usize())
+            }
         } else {
             // flush the entire TLB
-            asm!("tlbi vmalle1; dsb sy; isb")
+            #[cfg(not(feature = "hv"))]
+            {
+                asm!("tlbi vmalle1; dsb sy; isb")
+            }
+            #[cfg(feature = "hv")]
+            {
+                asm!("tlbi alle2is; dsb sy; isb")
+            }
         }
     }
 }
@@ -125,7 +153,11 @@ pub fn flush_dcache_line(vaddr: VirtAddr) {
 /// current CPU.
 #[inline]
 pub unsafe fn write_exception_vector_base(vbar_el1: usize) {
+    #[cfg(not(feature = "hv"))]
     VBAR_EL1.set(vbar_el1 as _);
+
+    #[cfg(feature = "hv")]
+    VBAR_EL2.set(vbar_el1 as _);
 }
 
 /// Reads the thread pointer of the current CPU (`TPIDR_EL0`).


### PR DESCRIPTION
# Adapted asm.rs for the Hypervisor scenario:
When the hv feature is enabled, the module now uses EL2-related registers and control flow. The original logic is preserved for non-Hypervisor configurations.