### PR TITLE
feat: `POST_TRAP` callback

### DIFF
--- a/src/aarch64/trap.S
+++ b/src/aarch64/trap.S
@@ -62,18 +62,20 @@
     b       .Lexception_return
 .endm
 
-.macro HANDLE_SYNC
+.macro HANDLE_SYNC, source
 .p2align 7
     SAVE_REGS
     mov     x0, sp
+    mov     x1, \source
     bl      handle_sync_exception
     b       .Lexception_return
 .endm
 
-.macro HANDLE_IRQ
+.macro HANDLE_IRQ, source
 .p2align 7
     SAVE_REGS
     mov     x0, sp
+    mov     x1, \source
     bl      handle_irq_exception
     b       .Lexception_return
 .endm
@@ -89,14 +91,14 @@ exception_vector_base:
     INVALID_EXCP 3 0
 
     // current EL, with SP_ELx
-    HANDLE_SYNC
-    HANDLE_IRQ
+    HANDLE_SYNC 1
+    HANDLE_IRQ 1
     INVALID_EXCP 2 1
     INVALID_EXCP 3 1
 
     // lower EL, aarch64
-    HANDLE_SYNC
-    HANDLE_IRQ
+    HANDLE_SYNC 2
+    HANDLE_IRQ 2
     INVALID_EXCP 2 2
     INVALID_EXCP 3 2
 

--- a/src/aarch64/trap.rs
+++ b/src/aarch64/trap.rs
@@ -26,6 +26,12 @@ enum TrapSource {
     LowerAArch32 = 3,
 }
 
+impl TrapSource {
+    fn is_from_user(&self) -> bool {
+        matches!(self, TrapSource::LowerAArch64 | TrapSource::LowerAArch32)
+    }
+}
+
 #[unsafe(no_mangle)]
 fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
     panic!(
@@ -35,8 +41,9 @@ fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
 }
 
 #[unsafe(no_mangle)]
-fn handle_irq_exception(_tf: &TrapFrame) {
+fn handle_irq_exception(tf: &mut TrapFrame, source: TrapSource) {
     handle_trap!(IRQ, 0);
+    crate::trap::post_trap_callback(tf, source.is_from_user());
 }
 
 fn handle_instruction_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
@@ -92,7 +99,7 @@ fn handle_data_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
 }
 
 #[unsafe(no_mangle)]
-fn handle_sync_exception(tf: &mut TrapFrame) {
+fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
     let esr = ESR_EL1.extract();
     let iss = esr.read(ESR_EL1::ISS);
     match esr.read_as_enum(ESR_EL1::EC) {
@@ -118,4 +125,5 @@ fn handle_sync_exception(tf: &mut TrapFrame) {
             );
         }
     }
+    crate::trap::post_trap_callback(tf, source.is_from_user());
 }

--- a/src/loongarch64/trap.rs
+++ b/src/loongarch64/trap.rs
@@ -70,4 +70,6 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             );
         }
     }
+
+    crate::trap::post_trap_callback(tf, from_user);
 }

--- a/src/riscv/trap.rs
+++ b/src/riscv/trap.rs
@@ -60,6 +60,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 panic!("Unhandled trap {:?} @ {:#x}:\n{:#x?}", cause, tf.sepc, tf);
             }
         }
+        crate::trap::post_trap_callback(tf, from_user);
     } else {
         panic!(
             "Unknown trap {:#x?} @ {:#x}:\n{:#x?}",

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -21,6 +21,10 @@ pub static PAGE_FAULT: [fn(VirtAddr, PageFaultFlags, bool) -> bool];
 #[def_trap_handler]
 pub static SYSCALL: [fn(&TrapFrame, usize) -> isize];
 
+/// A slice of callbacks to be invoked after a trap.
+#[linkme::distributed_slice]
+pub static POST_TRAP: [fn(&mut TrapFrame, bool)];
+
 #[allow(unused_macros)]
 macro_rules! handle_trap {
     ($trap:ident, $($args:tt)*) => {{
@@ -35,6 +39,13 @@ macro_rules! handle_trap {
             false
         }
     }}
+}
+
+#[unsafe(no_mangle)]
+pub(crate) fn post_trap_callback(tf: &mut TrapFrame, from_user: bool) {
+    for cb in crate::trap::POST_TRAP.iter() {
+        cb(tf, from_user);
+    }
 }
 
 /// Call the external syscall handler.

--- a/src/x86_64/syscall.rs
+++ b/src/x86_64/syscall.rs
@@ -17,6 +17,7 @@ core::arch::global_asm!(
 #[unsafe(no_mangle)]
 pub(super) fn x86_syscall_handler(tf: &mut TrapFrame) {
     tf.rax = crate::trap::handle_syscall(tf, tf.rax as usize) as u64;
+    crate::trap::post_trap_callback(tf, true);
 }
 
 /// Initializes syscall support and setups the syscall handler.

--- a/src/x86_64/trap.rs
+++ b/src/x86_64/trap.rs
@@ -56,6 +56,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
+    crate::trap::post_trap_callback(tf, tf.is_user());
 }
 
 fn vec_to_str(vec: u64) -> &'static str {


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: oscomp/arceos#34

some linker script updates in https://github.com/arceos-org/arceos/pull/266

## Description
This pull request introduces a mechanism to invoke post-trap callbacks across multiple architectures, refactors exception handling in the AArch64 assembly code, and enhances the `TrapSource` enum with helper functionality. These changes aim to improve modularity and consistency in trap handling across the codebase.

### Post-Trap Callback Mechanism:

* [`src/trap.rs`](diffhunk://#diff-7b238ee720fbe3dc3c18aee439c9890b6d01b0446ce45ebba945a7d66a670d9fR24-R27): Introduced a distributed slice `POST_TRAP` for registering callbacks to be invoked after a trap, and added a `post_trap_callback` function to iterate through and call these callbacks. [[1]](diffhunk://#diff-7b238ee720fbe3dc3c18aee439c9890b6d01b0446ce45ebba945a7d66a670d9fR24-R27) [[2]](diffhunk://#diff-7b238ee720fbe3dc3c18aee439c9890b6d01b0446ce45ebba945a7d66a670d9fR44-R50)

* Various architecture-specific trap handlers (`src/loongarch64/trap.rs`, `src/riscv/trap.rs`, `src/x86_64/trap.rs`, `src/x86_64/syscall.rs`): Updated to call `post_trap_callback` with appropriate parameters after handling traps. [[1]](diffhunk://#diff-41f15f5eab048fe1866532f02871fc234e4fa46c62aa6acf39062665361146e7R73-R74) [[2]](diffhunk://#diff-74102461acae975694d016adc27a74aaff1d7b2ca73f9bc62541584521b2a680R63) [[3]](diffhunk://#diff-5389b8e9f2b454f4971dbcdc6cc04e1f411b308a93bae6026e1fda7dc8a23f01R59) [[4]](diffhunk://#diff-dbe65d6f2e92e2037f4d33be8c0d4b5890892d94c06f707ab1faf49015b6e3d9R20)

### AArch64 Exception Handling Refactor:

* [`src/aarch64/trap.S`](diffhunk://#diff-b4d8d75862db037fb4ff296e0c248f656825fe52ccebdd63b10fb33479303db9L65-R78): Updated macros `HANDLE_SYNC` and `HANDLE_IRQ` to accept a `source` parameter, and modified their invocations in `exception_vector_base` to pass the appropriate source value. This ensures that the source of the exception is explicitly tracked. [[1]](diffhunk://#diff-b4d8d75862db037fb4ff296e0c248f656825fe52ccebdd63b10fb33479303db9L65-R78) [[2]](diffhunk://#diff-b4d8d75862db037fb4ff296e0c248f656825fe52ccebdd63b10fb33479303db9L92-R101)

* [`src/aarch64/trap.rs`](diffhunk://#diff-4bb7b0cbdf6039a031b73b3654437847374d8dc0e484f985c0c17f8d9a4c1741L95-R102): Updated `handle_sync_exception` and `handle_irq_exception` to accept a `TrapSource` parameter, and integrated `post_trap_callback` into these functions to handle post-trap logic. [[1]](diffhunk://#diff-4bb7b0cbdf6039a031b73b3654437847374d8dc0e484f985c0c17f8d9a4c1741L95-R102) [[2]](diffhunk://#diff-4bb7b0cbdf6039a031b73b3654437847374d8dc0e484f985c0c17f8d9a4c1741R128) [[3]](diffhunk://#diff-4bb7b0cbdf6039a031b73b3654437847374d8dc0e484f985c0c17f8d9a4c1741L38-R46)

### Enhancements to `TrapSource`:

* [`src/aarch64/trap.rs`](diffhunk://#diff-4bb7b0cbdf6039a031b73b3654437847374d8dc0e484f985c0c17f8d9a4c1741R29-R34): Added an `is_from_user` method to the `TrapSource` enum to determine if a trap originated from user space. This simplifies checks for user-originated traps.

## Additional Notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.