### PR TITLE
fix: frequent context switch leads to IRQ being silenced

### DIFF
--- a/src/loongarch64/trap.rs
+++ b/src/loongarch64/trap.rs
@@ -37,8 +37,13 @@ fn handle_page_fault(tf: &TrapFrame, mut access_flags: PageFaultFlags, is_user: 
 #[unsafe(no_mangle)]
 fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
     let estat = estat::read();
+    let trap = estat.cause();
 
-    match estat.cause() {
+    if matches!(trap, Trap::Exception(_)) {
+        unmask_irqs(tf);
+    }
+
+    match trap {
         #[cfg(feature = "uspace")]
         Trap::Exception(Exception::Syscall) => {
             tf.regs.a0 = crate::trap::handle_syscall(tf, tf.regs.a7) as usize;
@@ -70,4 +75,28 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             );
         }
     }
+    mask_irqs();
+}
+
+// Interrupt unmasking function for exception handling.
+// NOTE: It must be invoked after the switch to kernel mode has finished
+//
+// If interrupts were enabled before the exception (`PIE` bit in `PRMD` is set),
+// re-enable interrupts before handling the exception.
+//
+// On loongarch64, when an exception is triggered, records the old value of
+// `IE` domain in `CSR.CRMD` in `PIE` domain in `PRMD`. When the `ERTN`
+// instruction is executed to return from the exception handler, the hardware
+// restores the value of the `PIE` domain to the `IE` domain of `CSR.CRMD`.
+fn unmask_irqs(tf: &TrapFrame) {
+    const PIE: usize = 1 << 2;
+    if tf.prmd & PIE == PIE {
+        crate::asm::enable_irqs();
+    } else {
+        debug!("Interrupts were disabled before exception");
+    }
+}
+
+fn mask_irqs() {
+    crate::asm::disable_irqs();
 }

--- a/src/riscv/trap.rs
+++ b/src/riscv/trap.rs
@@ -1,3 +1,4 @@
+use memory_addr::VirtAddr;
 use riscv::interrupt::supervisor::{Exception as E, Interrupt as I};
 use riscv::interrupt::Trap;
 use riscv::register::{scause, stval};
@@ -16,11 +17,15 @@ fn handle_breakpoint(sepc: &mut usize) {
     *sepc += 2
 }
 
-fn handle_page_fault(tf: &TrapFrame, mut access_flags: PageFaultFlags, is_user: bool) {
+fn handle_page_fault(
+    tf: &TrapFrame,
+    vaddr: VirtAddr,
+    mut access_flags: PageFaultFlags,
+    is_user: bool,
+) {
     if is_user {
         access_flags |= PageFaultFlags::USER;
     }
-    let vaddr = va!(stval::read());
     if !handle_trap!(PAGE_FAULT, vaddr, access_flags, is_user) {
         panic!(
             "Unhandled {} Page Fault @ {:#x}, fault_vaddr={:#x} ({:?}):\n{:#x?}",
@@ -37,6 +42,12 @@ fn handle_page_fault(tf: &TrapFrame, mut access_flags: PageFaultFlags, is_user: 
 fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
     let scause = scause::read();
     if let Ok(cause) = scause.cause().try_into::<I, E>() {
+        // Interrupts modify the value of `stval`, which must be saved before the
+        // interrupt is enabled
+        let vaddr = va!(stval::read());
+        if scause.is_exception() {
+            unmask_irqs(tf);
+        }
         match cause {
             #[cfg(feature = "uspace")]
             Trap::Exception(E::UserEnvCall) => {
@@ -44,13 +55,13 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 tf.sepc += 4;
             }
             Trap::Exception(E::LoadPageFault) => {
-                handle_page_fault(tf, PageFaultFlags::READ, from_user)
+                handle_page_fault(tf, vaddr, PageFaultFlags::READ, from_user)
             }
             Trap::Exception(E::StorePageFault) => {
-                handle_page_fault(tf, PageFaultFlags::WRITE, from_user)
+                handle_page_fault(tf, vaddr, PageFaultFlags::WRITE, from_user)
             }
             Trap::Exception(E::InstructionPageFault) => {
-                handle_page_fault(tf, PageFaultFlags::EXECUTE, from_user)
+                handle_page_fault(tf, vaddr, PageFaultFlags::EXECUTE, from_user)
             }
             Trap::Exception(E::Breakpoint) => handle_breakpoint(&mut tf.sepc),
             Trap::Interrupt(_) => {
@@ -68,4 +79,27 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             tf
         );
     }
+    mask_irqs();
+}
+
+// Interrupt unmasking function for exception handling.
+// NOTE: It must be invoked after the switch to kernel mode has finished
+//
+// If interrupts were enabled before the exception (the `SPIE` bit in the
+// `sstatus` register is set), re-enable interrupts before exception handling
+//
+// On riscv64, when an exception occurs, `sstatus.SIE` is set to zero to mask
+// the interrupt and the old value of `SIE` is stored in SPIE. Recover `SIE`
+// according to `SPIE` when using `sret`.
+fn unmask_irqs(tf: &TrapFrame) {
+    const PIE: usize = 1 << 5;
+    if tf.sstatus & PIE == PIE {
+        crate::asm::enable_irqs();
+    } else {
+        debug!("Interrupts were disabled before exception");
+    }
+}
+
+fn mask_irqs() {
+    crate::asm::disable_irqs();
 }

--- a/src/x86_64/syscall.rs
+++ b/src/x86_64/syscall.rs
@@ -16,7 +16,11 @@ core::arch::global_asm!(
 
 #[unsafe(no_mangle)]
 pub(super) fn x86_syscall_handler(tf: &mut TrapFrame) {
+    #[cfg(target_os = "none")]
+    super::trap::unmask_irqs(tf);
     tf.rax = crate::trap::handle_syscall(tf, tf.rax as usize) as u64;
+    #[cfg(target_os = "none")]
+    super::trap::mask_irqs();
 }
 
 /// Initializes syscall support and setups the syscall handler.


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: oscomp/arceos#42, oscomp/arceos#44

## Description
This pull request introduces interrupt masking and unmasking functionality across multiple architectures to ensure proper handling of exceptions and interrupts. The changes add `mask_irqs` and `unmask_irqs` functions for managing interrupt states and integrate them into various exception and interrupt handlers.

## Additional Notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.