### PR TITLE
fix(riscv): pad TrapFrame to multiple of 16 bytes

### DIFF
--- a/src/riscv/context.rs
+++ b/src/riscv/context.rs
@@ -7,6 +7,7 @@ use riscv::register::sstatus::{self, FS};
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct GeneralRegisters {
+    pub zero: usize,
     pub ra: usize,
     pub sp: usize,
     pub gp: usize, // only valid for user traps

--- a/src/riscv/macros.rs
+++ b/src/riscv/macros.rs
@@ -137,34 +137,34 @@ macro_rules! include_asm_macros {
             .equ REGS_MACROS_FLAG, 1
 
             .macro PUSH_POP_GENERAL_REGS, op
-                \op ra, sp, 0
-                \op t0, sp, 4
-                \op t1, sp, 5
-                \op t2, sp, 6
-                \op s0, sp, 7
-                \op s1, sp, 8
-                \op a0, sp, 9
-                \op a1, sp, 10
-                \op a2, sp, 11
-                \op a3, sp, 12
-                \op a4, sp, 13
-                \op a5, sp, 14
-                \op a6, sp, 15
-                \op a7, sp, 16
-                \op s2, sp, 17
-                \op s3, sp, 18
-                \op s4, sp, 19
-                \op s5, sp, 20
-                \op s6, sp, 21
-                \op s7, sp, 22
-                \op s8, sp, 23
-                \op s9, sp, 24
-                \op s10, sp, 25
-                \op s11, sp, 26
-                \op t3, sp, 27
-                \op t4, sp, 28
-                \op t5, sp, 29
-                \op t6, sp, 30
+                \op ra, sp, 1
+                \op t0, sp, 5
+                \op t1, sp, 6
+                \op t2, sp, 7
+                \op s0, sp, 8
+                \op s1, sp, 9
+                \op a0, sp, 10
+                \op a1, sp, 11
+                \op a2, sp, 12
+                \op a3, sp, 13
+                \op a4, sp, 14
+                \op a5, sp, 15
+                \op a6, sp, 16
+                \op a7, sp, 17
+                \op s2, sp, 18
+                \op s3, sp, 19
+                \op s4, sp, 20
+                \op s5, sp, 21
+                \op s6, sp, 22
+                \op s7, sp, 23
+                \op s8, sp, 24
+                \op s9, sp, 25
+                \op s10, sp, 26
+                \op s11, sp, 27
+                \op t3, sp, 28
+                \op t4, sp, 29
+                \op t5, sp, 30
+                \op t6, sp, 31
             .endm
 
             .macro PUSH_GENERAL_REGS

--- a/src/riscv/trap.S
+++ b/src/riscv/trap.S
@@ -5,15 +5,15 @@
     csrr    t0, sepc
     csrr    t1, sstatus
     csrrw   t2, sscratch, zero          // save sscratch (sp) and zero it
-    STR     t0, sp, 31                  // tf.sepc
-    STR     t1, sp, 32                  // tf.sstatus
-    STR     t2, sp, 1                   // tf.regs.sp
+    STR     t0, sp, 32                  // tf.sepc
+    STR     t1, sp, 33                  // tf.sstatus
+    STR     t2, sp, 2                   // tf.regs.sp
 
 .if \from_user == 1
-    LDR     t0, sp, 2                   // load supervisor gp
-    LDR     t1, sp, 3                   // load supervisor tp
-    STR     gp, sp, 2                   // save user gp and tp
-    STR     tp, sp, 3
+    LDR     t0, sp, 3                   // load supervisor gp
+    LDR     t1, sp, 4                   // load supervisor tp
+    STR     gp, sp, 3                   // save user gp
+    STR     tp, sp, 4                   // save user tp
     mv      gp, t0
     mv      tp, t1
 .endif
@@ -21,23 +21,23 @@
 
 .macro RESTORE_REGS, from_user
 .if \from_user == 1
-    LDR     t1, sp, 2                   // load user gp and tp
-    LDR     t0, sp, 3
-    STR     gp, sp, 2                   // save supervisor gp
-    STR     tp, sp, 3                   // save supervisor gp and tp
+    LDR     t1, sp, 3                   // load user gp
+    LDR     t0, sp, 4                   // load user tp
+    STR     gp, sp, 3                   // save supervisor gp
+    STR     tp, sp, 4                   // save supervisor tp
     mv      gp, t1
     mv      tp, t0
     addi    t0, sp, {trapframe_size}    // put supervisor sp to scratch
     csrw    sscratch, t0
 .endif
 
-    LDR     t0, sp, 31
-    LDR     t1, sp, 32
+    LDR     t0, sp, 32
+    LDR     t1, sp, 33
     csrw    sepc, t0                    // restore sepc
     csrw    sstatus, t1                 // restore sstatus, except FS state (already handled in trap handler)
 
     POP_GENERAL_REGS
-    LDR     sp, sp, 1                   // load sp from tf.regs.sp
+    LDR     sp, sp, 2                   // load sp from tf.regs.sp
 .endm
 
 .section .text

--- a/src/riscv/uspace.rs
+++ b/src/riscv/uspace.rs
@@ -91,16 +91,16 @@ impl UspaceContext {
                 "
                 mv      sp, {tf}
 
-                STR     gp, {kernel_trap_addr}, 2
-                LDR     gp, sp, 2
+                STR     gp, {kernel_trap_addr}, 3
+                LDR     gp, sp, 3
 
-                STR     tp, {kernel_trap_addr}, 3
-                LDR     tp, sp, 3
+                STR     tp, {kernel_trap_addr}, 4
+                LDR     tp, sp, 4
 
-                LDR     t0, sp, 32
+                LDR     t0, sp, 33
                 csrw    sstatus, t0
                 POP_GENERAL_REGS
-                LDR     sp, sp, 1
+                LDR     sp, sp, 2
                 sret",
                 tf = in(reg) &(self.0),
                 kernel_trap_addr = in(reg) kernel_trap_addr,


### PR DESCRIPTION
This PR pads the `TrapFrame` of RISC-V to multiple of 16 bytes to make sure that the stack pointer of the trap handler is aligned to 16 bytes.

The implementation is similar to the one of LoongArch64.
