### PR TITLE
Fix kernel stack pointer save on LoongArch64 (again)

### DIFF
--- a/src/loongarch64/asm.rs
+++ b/src/loongarch64/asm.rs
@@ -185,15 +185,3 @@ pub fn enable_fp() {
 pub fn enable_lsx() {
     loongArch64::register::euen::set_sxe(true);
 }
-
-/// Writes the kernel stack pointer into the custom `KSAVE_KSP` CSR.
-#[cfg(feature = "uspace")]
-pub(crate) fn write_kernel_sp(kernel_sp: usize) {
-    unsafe {
-        asm!(
-            include_asm_macros!(),
-            "csrwr {}, KSAVE_KSP",
-            in(reg) kernel_sp
-        )
-    }
-}

--- a/src/loongarch64/context.rs
+++ b/src/loongarch64/context.rs
@@ -179,7 +179,6 @@ impl TaskContext {
         }
         #[cfg(feature = "uspace")]
         {
-            crate::asm::write_kernel_sp(next_ctx.sp);
             if self.pgdl != next_ctx.pgdl {
                 unsafe { crate::asm::write_user_page_table(pa!(next_ctx.pgdl)) };
                 crate::asm::flush_tlb(None); // currently flush the entire TLB

--- a/src/loongarch64/trap.S
+++ b/src/loongarch64/trap.S
@@ -27,6 +27,8 @@
     csrwr   $r21, KSAVE_R21
     LDD     $tp,  $sp, 2
     LDD     $r21, $sp, 21
+    addi.d  $t1,  $sp, {trapframe_size}
+    csrwr   $t1,  KSAVE_KSP     // save kernel sp
 .endif
 
     LDD     $t1,  $sp, 33       // era

--- a/src/loongarch64/uspace.rs
+++ b/src/loongarch64/uspace.rs
@@ -70,7 +70,6 @@ impl UspaceContext {
         use loongArch64::register::era;
 
         crate::asm::disable_irqs();
-        crate::asm::write_kernel_sp(kstack_top.as_usize());
         era::set_pc(self.get_ip());
 
         unsafe {
@@ -82,6 +81,7 @@ impl UspaceContext {
                 csrwr     $r21, KSAVE_R21
                 LDD       $tp,  $sp, 32
                 csrwr     $tp,  LA_CSR_PRMD
+                csrwr     {kstack_top}, KSAVE_KSP // save ksp into SAVE0 CSR
 
                 POP_GENERAL_REGS
 
@@ -90,6 +90,7 @@ impl UspaceContext {
                 LDD      $sp,   $sp, 3       // user sp
                 ertn",
                 tf = in (reg) &self.0,
+                kstack_top = in(reg) kstack_top.as_usize(),
                 options(noreturn),
             )
         }


### PR DESCRIPTION
## Description
The fix proposed previously at https://github.com/arceos-org/axcpu/commit/7152ea53bdb30bc5fc041b92ea4f603456efdfab is wrong. `next_ctx.sp`, which is saved in the previous `context_switch`, is never the top of kernel stack.

This PR fixs this by porting https://github.com/oscomp/arceos/pull/18.

## Comparison
As said in https://github.com/arceos-org/arceos/issues/229, the previous fix tried to take a similar approach to x86_64. But x86_64's `TaskContext` has a fixed `kstack_top` field, so this is correct.

I believe there is no need to reduce the times to save kernel sp on LoongArch64 since on x86_64 each save and load involves a memory operation but here we just read and write registers, which is the same way `sscratch` is used on RISC-V.