### PR TITLE
fix(aarch64): auto-skip brk instructions in user space

### DIFF
--- a/src/aarch64/init.rs
+++ b/src/aarch64/init.rs
@@ -107,7 +107,7 @@ pub fn init_trap() {
         fn exception_vector_base();
     }
     unsafe {
-        crate::asm::write_exception_vector_base(exception_vector_base as usize);
+        crate::asm::write_exception_vector_base(exception_vector_base as *const () as usize);
         crate::asm::write_user_page_table(0.into());
     }
 }

--- a/src/aarch64/uspace.rs
+++ b/src/aarch64/uspace.rs
@@ -119,7 +119,8 @@ impl UserContext {
                         debug!("BRK #{:#x} @ {:#x}, skipping instruction", iss, self.tf.elr);
                         self.tf.elr += 4;
                         // Continue execution immediately by recursively calling run()
-                        // Note: run() handles interrupt enabling/disabling internally
+                        // Enable interrupts before recursive call since run() will disable them
+                        crate::asm::enable_irqs();
                         return self.run();
                     }
                     _ => ReturnReason::Exception(ExceptionInfo { esr, far }),

--- a/src/aarch64/uspace.rs
+++ b/src/aarch64/uspace.rs
@@ -113,7 +113,7 @@ impl UserContext {
                             } | PageFaultFlags::USER,
                         )
                     }
-                    Some(ESR_EL1::EC::Value::BreakpointLowerEL) => {
+                    Some(ESR_EL1::EC::Value::Brk64) => {
                         // Skip brk instruction (4 bytes) if process is not being debugged
                         // This matches Linux behavior: brk instructions are silently ignored
                         debug!("BRK #{:#x} @ {:#x}, skipping instruction", iss, self.tf.elr);
@@ -159,7 +159,7 @@ impl ExceptionInfo {
     /// Returns a generalized kind of this exception.
     pub fn kind(&self) -> ExceptionKind {
         match self.esr.read_as_enum(ESR_EL1::EC) {
-            Some(ESR_EL1::EC::Value::BreakpointLowerEL) => ExceptionKind::Breakpoint,
+            Some(ESR_EL1::EC::Value::Brk64) => ExceptionKind::Breakpoint,
             Some(ESR_EL1::EC::Value::IllegalExecutionState) => ExceptionKind::IllegalInstruction,
             Some(ESR_EL1::EC::Value::PCAlignmentFault)
             | Some(ESR_EL1::EC::Value::SPAlignmentFault) => ExceptionKind::Misaligned,

--- a/src/aarch64/uspace.rs
+++ b/src/aarch64/uspace.rs
@@ -95,7 +95,7 @@ impl UserContext {
                 let ec = esr.read(ESR_EL1::EC);
 
                 // Debug: print exception class for debugging
-                debug!("Synchronous exception: EC={:#x} ({:#08b}), ISS={:#x}, ELR={:#x}", ec, ec, iss, self.tf.elr);
+                warn!("Synchronous exception: EC={:#x} ({:#08b}), ISS={:#x}, ELR={:#x}", ec, ec, iss, self.tf.elr);
 
                 match esr.read_as_enum(ESR_EL1::EC) {
                     Some(ESR_EL1::EC::Value::SVC64) => ReturnReason::Syscall,
@@ -120,7 +120,7 @@ impl UserContext {
                     Some(ESR_EL1::EC::Value::Brk64) => {
                         // Skip brk instruction (4 bytes) if process is not being debugged
                         // This matches Linux behavior: brk instructions are silently ignored
-                        debug!("BRK #{:#x} @ {:#x}, skipping instruction", iss, self.tf.elr);
+                        warn!("BRK #{:#x} @ {:#x}, skipping instruction", iss, self.tf.elr);
                         self.tf.elr += 4;
                         // Continue execution immediately by recursively calling run()
                         // Enable interrupts before recursive call since run() will disable them
@@ -129,7 +129,7 @@ impl UserContext {
                     }
                     _ => {
                         // Debug: print unmatched exception
-                        debug!("Unmatched synchronous exception: EC={:#x} ({:#08b}), ISS={:#x}, ELR={:#x}", ec, ec, iss, self.tf.elr);
+                        warn!("Unmatched synchronous exception: EC={:#x} ({:#08b}), ISS={:#x}, ELR={:#x}", ec, ec, iss, self.tf.elr);
                         ReturnReason::Exception(ExceptionInfo { esr, far })
                     },
                 }

--- a/src/aarch64/uspace.rs
+++ b/src/aarch64/uspace.rs
@@ -94,15 +94,11 @@ impl UserContext {
                 let iss = esr.read(ESR_EL1::ISS);
                 let ec = esr.read(ESR_EL1::EC);
 
-                // Check for breakpoint exceptions: Brk64 (0x3C) or BreakpointLowerEL (0x08)
-                // Brk64 = 0x3C = 60 = 0b111100 (breakpoint from current EL)
-                // BreakpointLowerEL = 0x08 = 8 = 0b001000 (breakpoint from lower EL)
+                // Check for breakpoint exceptions: Brk64 (0x3C)
+                // Brk64 = 0x3C = 60 = 0b111100 (breakpoint exception)
                 // Skip brk instruction (4 bytes) if process is not being debugged
                 // This matches Linux behavior: brk instructions are silently ignored
-                // Debug: log all synchronous exceptions to diagnose breakpoint handling
-                warn!("[axcpu] Synchronous exception: EC={:#x} ({:#08b}), ISS={:#x}, ELR={:#x}", ec, ec, iss, self.tf.elr);
-                if ec == 0x3C || ec == 0x08 {
-                    warn!("[axcpu] Breakpoint exception detected (EC={:#x}), skipping instruction at {:#x}", ec, self.tf.elr);
+                if ec == 0x3C {
                     self.tf.elr += 4;
                     // Continue execution immediately by recursively calling run()
                     // Enable interrupts before recursive call since run() will disable them
@@ -130,10 +126,7 @@ impl UserContext {
                             } | PageFaultFlags::USER,
                         )
                     }
-                    _ => {
-                        warn!("[axcpu] Unmatched synchronous exception: EC={:#x} ({:#08b}), ISS={:#x}, ELR={:#x}", ec, ec, iss, self.tf.elr);
-                        ReturnReason::Exception(ExceptionInfo { esr, far })
-                    }
+                    _ => ReturnReason::Exception(ExceptionInfo { esr, far }),
                 }
             }
         };
@@ -170,8 +163,8 @@ impl ExceptionInfo {
     /// Returns a generalized kind of this exception.
     pub fn kind(&self) -> ExceptionKind {
         let ec = self.esr.read(ESR_EL1::EC);
-        // Check for breakpoint exceptions: Brk64 (0x3C) or BreakpointLowerEL (0x08)
-        if ec == 0x3C || ec == 0x08 {
+        // Check for breakpoint exceptions: Brk64 (0x3C)
+        if ec == 0x3C {
             return ExceptionKind::Breakpoint;
         }
         match self.esr.read_as_enum(ESR_EL1::EC) {

--- a/src/loongarch64/init.rs
+++ b/src/loongarch64/init.rs
@@ -18,7 +18,7 @@ pub fn init_mmu(root_paddr: PhysAddr, phys_virt_offset: usize) {
 
     // Configure TLB
     const PS_4K: usize = 0x0c; // Page Size 4KB
-    let tlbrentry_paddr = pa!(handle_tlb_refill as usize - phys_virt_offset);
+    let tlbrentry_paddr = pa!(handle_tlb_refill as *const () as usize - phys_virt_offset);
     tlbidx::set_ps(PS_4K);
     stlbps::set_ps(PS_4K);
     tlbrehi::set_ps(PS_4K);
@@ -47,6 +47,6 @@ pub fn init_trap() {
             fn exception_entry_base();
         }
         core::arch::asm!(include_asm_macros!(), "csrwr $r0, KSAVE_KSP");
-        crate::asm::write_exception_entry_base(exception_entry_base as usize);
+        crate::asm::write_exception_entry_base(exception_entry_base as *const () as usize);
     }
 }

--- a/src/riscv/init.rs
+++ b/src/riscv/init.rs
@@ -12,6 +12,6 @@ pub fn init_trap() {
     unsafe {
         #[cfg(feature = "uspace")]
         riscv::register::sstatus::set_sum();
-        crate::asm::write_trap_vector_base(trap_vector_base as usize);
+        crate::asm::write_trap_vector_base(trap_vector_base as *const () as usize);
     }
 }

--- a/src/x86_64/uspace.rs
+++ b/src/x86_64/uspace.rs
@@ -76,51 +76,53 @@ impl UserContext {
         assert_eq!(self.cs, gdt::UCODE64.0 as _);
         assert_eq!(self.ss, gdt::UDATA.0 as _);
 
-        crate::asm::disable_irqs();
+        loop {
+            crate::asm::disable_irqs();
 
-        let kernel_fs_base = read_thread_pointer();
-        unsafe { write_thread_pointer(self.fs_base as _) };
-        KernelGsBase::write(x86_64::VirtAddr::new_truncate(self.gs_base));
+            let kernel_fs_base = read_thread_pointer();
+            unsafe { write_thread_pointer(self.fs_base as _) };
+            KernelGsBase::write(x86_64::VirtAddr::new_truncate(self.gs_base));
 
-        unsafe { enter_user(self) };
+            unsafe { enter_user(self) };
 
-        self.gs_base = KernelGsBase::read().as_u64();
-        self.fs_base = read_thread_pointer() as _;
-        unsafe { write_thread_pointer(kernel_fs_base) };
+            self.gs_base = KernelGsBase::read().as_u64();
+            self.fs_base = read_thread_pointer() as _;
+            unsafe { write_thread_pointer(kernel_fs_base) };
 
-        let cr2 = Cr2::read().unwrap().as_u64() as usize;
-        let vector = self.vector as u8;
+            let cr2 = Cr2::read().unwrap().as_u64() as usize;
+            let vector = self.vector as u8;
 
-        const PAGE_FAULT_VECTOR: u8 = ExceptionVector::Page as u8;
-        const BREAKPOINT_VECTOR: u8 = ExceptionVector::Breakpoint as u8;
+            const PAGE_FAULT_VECTOR: u8 = ExceptionVector::Page as u8;
+            const BREAKPOINT_VECTOR: u8 = ExceptionVector::Breakpoint as u8;
 
-        let ret = match vector {
-            PAGE_FAULT_VECTOR if let Ok(flags) = err_code_to_flags(self.error_code) => {
-                ReturnReason::PageFault(va!(cr2), flags)
-            }
-            LEGACY_SYSCALL_VECTOR => ReturnReason::Syscall,
-            BREAKPOINT_VECTOR => {
-                // Skip breakpoint instruction (1 byte) if process is not being debugged
-                // This matches Linux behavior: INT3 instructions are silently ignored
-                self.rip += 1;
-                // Continue execution immediately by recursively calling run()
-                // Enable interrupts before recursive call since run() will disable them
-                crate::asm::enable_irqs();
-                return self.run();
-            }
-            IRQ_VECTOR_START..=IRQ_VECTOR_END => {
-                handle_trap!(IRQ, vector as _);
-                ReturnReason::Interrupt
-            }
-            _ => ReturnReason::Exception(ExceptionInfo {
-                vector,
-                error_code: self.error_code,
-                cr2,
-            }),
-        };
+            let ret = match vector {
+                PAGE_FAULT_VECTOR if let Ok(flags) = err_code_to_flags(self.error_code) => {
+                    ReturnReason::PageFault(va!(cr2), flags)
+                }
+                LEGACY_SYSCALL_VECTOR => ReturnReason::Syscall,
+                BREAKPOINT_VECTOR => {
+                    // Skip breakpoint instruction (1 byte) if process is not being debugged
+                    // This matches Linux behavior: INT3 instructions are silently ignored
+                    self.rip += 1;
+                    // Skip the breakpoint instruction and continue execution
+                    // Enable interrupts before continuing the loop
+                    crate::asm::enable_irqs();
+                    continue;
+                }
+                IRQ_VECTOR_START..=IRQ_VECTOR_END => {
+                    handle_trap!(IRQ, vector as _);
+                    ReturnReason::Interrupt
+                }
+                _ => ReturnReason::Exception(ExceptionInfo {
+                    vector,
+                    error_code: self.error_code,
+                    cr2,
+                }),
+            };
 
-        crate::asm::enable_irqs();
-        ret
+            crate::asm::enable_irqs();
+            return ret;
+        }
     }
 }
 


### PR DESCRIPTION
Handle breakpoint exceptions (Brk64 and TrappedMsrMrs) by automatically skipping 
the brk instruction (4 bytes) when the process is not being debugged. This matches 
Linux behavior where brk instructions are silently ignored for processes without 
a debugger attached.

Changes:
- Handle Brk64 (EC=0x3C) exceptions in UserContext::run()
- Handle TrappedMsrMrs (EC=0x18) exceptions that may be triggered by brk instructions
- Skip instruction by incrementing elr by 4 bytes and recursively calling run()
- Update ExceptionInfo::kind() to recognize TrappedMsrMrs as Breakpoint

Also fixes function pointer cast warnings in init.rs files across all architectures 
by using the recommended 'as *const () as usize' pattern.