### PR TITLE
fix(riscv): set FP state before restore or clear

### DIFF
--- a/src/riscv/context.rs
+++ b/src/riscv/context.rs
@@ -65,6 +65,15 @@ impl Default for FpState {
 
 #[cfg(feature = "fp-simd")]
 impl FpState {
+    /// Enables FP/SIMD instructions before issuing FP register operations.
+    ///
+    /// On some boot paths (e.g., with different firmware), `sstatus.FS` may be
+    /// `Off`, where FP instructions trap as `IllegalInstruction`
+    #[inline]
+    fn enable_fp_instructions() {
+        unsafe { sstatus::set_fs(FS::Dirty) };
+    }
+
     /// Restores the floating-point registers from this FP state
     #[inline]
     pub fn restore(&self) {
@@ -98,9 +107,15 @@ impl FpState {
         }
         // restore the next task's FP state
         match next_fp_state.fs {
-            FS::Clean => next_fp_state.restore(), // the next task's FP state is clean, we should restore it
-            FS::Initial => FpState::clear(),      // restore the FP state as constant values(all 0)
-            FS::Off => {}                         // do nothing
+            FS::Clean => {
+                FpState::enable_fp_instructions();
+                next_fp_state.restore(); // the next task's FP state is clean, we should restore it
+            }
+            FS::Initial => {
+                FpState::enable_fp_instructions();
+                FpState::clear(); // restore the FP state as constant values(all 0)
+            }
+            FS::Off => {} // do nothing
             FS::Dirty => unreachable!("FP state of the next task should not be dirty"),
         }
         unsafe { sstatus::set_fs(next_fp_state.fs) }; // set the FP state to the next task's FP state

--- a/src/riscv/context.rs
+++ b/src/riscv/context.rs
@@ -68,10 +68,10 @@ impl FpState {
     /// Enables FP/SIMD instructions before issuing FP register operations.
     ///
     /// On some boot paths (e.g., with different firmware), `sstatus.FS` may be
-    /// `Off`, where FP instructions trap as `IllegalInstruction`
+    /// `Off`, where FP instructions trap as `IllegalInstruction`.
     #[inline]
     fn enable_fp_instructions() {
-        unsafe { sstatus::set_fs(FS::Dirty) };
+        unsafe { sstatus::set_fs(FS::Initial) };
     }
 
     /// Restores the floating-point registers from this FP state

--- a/src/riscv/context.rs
+++ b/src/riscv/context.rs
@@ -65,15 +65,6 @@ impl Default for FpState {
 
 #[cfg(feature = "fp-simd")]
 impl FpState {
-    /// Enables FP/SIMD instructions before issuing FP register operations.
-    ///
-    /// On some boot paths (e.g., with different firmware), `sstatus.FS` may be
-    /// `Off`, where FP instructions trap as `IllegalInstruction`.
-    #[inline]
-    fn enable_fp_instructions() {
-        unsafe { sstatus::set_fs(FS::Initial) };
-    }
-
     /// Restores the floating-point registers from this FP state
     #[inline]
     pub fn restore(&self) {
@@ -105,20 +96,15 @@ impl FpState {
             // after saving, we set the FP state to clean
             self.fs = FS::Clean;
         }
+        // set the FP state to the next task's FP state.
+        unsafe { sstatus::set_fs(next_fp_state.fs) };
         // restore the next task's FP state
         match next_fp_state.fs {
-            FS::Clean => {
-                FpState::enable_fp_instructions();
-                next_fp_state.restore(); // the next task's FP state is clean, we should restore it
-            }
-            FS::Initial => {
-                FpState::enable_fp_instructions();
-                FpState::clear(); // restore the FP state as constant values(all 0)
-            }
-            FS::Off => {} // do nothing
+            FS::Clean => next_fp_state.restore(), // the next task's FP state is clean, we should restore it
+            FS::Initial => FpState::clear(),      // restore the FP state as constant values(all 0)
+            FS::Off => {}                         // do nothing
             FS::Dirty => unreachable!("FP state of the next task should not be dirty"),
         }
-        unsafe { sstatus::set_fs(next_fp_state.fs) }; // set the FP state to the next task's FP state
     }
 }
 


### PR DESCRIPTION
### Background
When booting downstream StarryOS on riscv64 with RustSBI, the kernel could panic with:
- `Unhandled trap Exception(IllegalInstruction)`
- `stval=0xf2000053`
- stack trace around task switching / fp-simd context switch path
The same workload could boot under other firmware setups, indicating a firmware-dependent FP init assumption.
(Downstream context: Starry-OS/StarryOS#130, Starry-OS/StarryOS#131)
### Root Cause
In `axcpu` RISC-V fp-simd context switching, FP instructions can be executed in `restore/clear` paths while `sstatus.FS` is still `Off` on some boot paths/harts.
When `FS=Off`, executing FP instructions (e.g. `fld` / `fmv.d.x`) traps as `IllegalInstruction`.
So the issue is not OS entry order itself, but a missing local precondition in the `axcpu` FP context switch path.

A common trigger is switching from a task that does not use FP (`FS=Off`) to one that needs FP state restore/initialization, where FP instructions in the switch path can trap before the next task actually runs.

### Changes
This PR fixes the issue at the root-cause location in `axcpu`:
1. `src/riscv/context.rs`
   - Add a small helper:
     - `FpState::enable_fp_instructions()`
   - In `FpState::switch_to()`:
     - Before `next_fp_state.restore()` (`FS::Clean` branch), explicitly enable FP execution.
     - Before `FpState::clear()` (`FS::Initial` branch), explicitly enable FP execution.
   - Keep existing post-switch behavior unchanged:
     - still sets `sstatus.FS` to `next_fp_state.fs` at the end.
### Validation Performed
- Local:
  - `cargo fmt --all -- --check` passes.
- Behavioral/functional validation is from downstream reproduction:
  - With this fix concept applied, RustSBI boot no longer hits the `IllegalInstruction` trap in fp-simd switching path.
### Impact
- Makes RISC-V fp-simd context switching robust when firmware leaves `sstatus.FS=Off`.
## Files Included In This PR
- `src/riscv/context.rs`

> I’m still learning kernel development, so feedback is very welcome.
> If any part of this fix should be done differently, I’m happy to revise.