### PR TITLE
feat(riscv): Add feature for T-Head CPU xuanite-c9xx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ fp-simd = []
 tls = []
 uspace = []
 arm-el2 = []
+xuanite-c9xx = [] # ["page_table_entry/xuanite-c9xx"]
 
 [dependencies]
 linkme = "0.3"

--- a/src/riscv/uspace.rs
+++ b/src/riscv/uspace.rs
@@ -26,6 +26,8 @@ impl UspaceContext {
         {
             sstatus.set_fs(FS::Initial); // set the FPU to initial state
         }
+        #[cfg(feature = "xuanite-c9xx")]
+        unsafe{ set_sstatus(&mut sstatus, (0x3 << 23), false); } // enable vector status bits of sstatus
 
         Self(TrapFrame {
             regs: GeneralRegisters {
@@ -51,6 +53,22 @@ impl UspaceContext {
     /// Gets the stack pointer.
     pub const fn get_sp(&self) -> usize {
         self.0.regs.sp
+    }
+
+    /// Sets the sstatus register.
+    /// Due to the restriction of Sstatus struct, some bits of the sstatus register cannot be effectively set,
+    /// So this function can effectively set the required bits of sstatus.
+    pub unsafe fn set_sstatus(sstatus: &mut Sstatus, bits: usize, is_clear: bool) {
+        if bits == 0 {
+            error!("Invalid parameter: {:x}", bits);
+            return;
+        }
+        let sstatus_ptr = sstatus as *mut Sstatus as *mut usize;
+        if is_clear {
+            *sstatus_ptr &= !bits;
+        } else {
+            *sstatus_ptr |= bits;
+        }
     }
 
     /// Sets the instruction pointer.
@@ -80,6 +98,9 @@ impl UspaceContext {
     /// This function is unsafe because it changes processor mode and the stack.
     pub unsafe fn enter_uspace(&self, kstack_top: VirtAddr) -> ! {
         use riscv::register::{sepc, sscratch};
+        use riscv::asm::fence_i;
+
+        fence_i();
 
         crate::asm::disable_irqs();
         // Address of the top of the kernel stack after saving the trap frame.


### PR DESCRIPTION
* Add the extended setting function for the sstatus register And, before entering the user program space, refresh all instruction caches to resolve user program errors that occur on xuanite-c9xx platform